### PR TITLE
Add AbstractPluginHook base class for plugin integration

### DIFF
--- a/src/main/java/de/varilx/hook/AbstractPluginHook.java
+++ b/src/main/java/de/varilx/hook/AbstractPluginHook.java
@@ -1,0 +1,34 @@
+package de.varilx.hook;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Project: base-api
+ * Package: de.varilx.hook
+ * <p>
+ * Author: ShadowDev1929
+ * Created on: 01.01.2025
+ */
+
+@Getter
+@FieldDefaults(level = AccessLevel.PROTECTED)
+public abstract class AbstractPluginHook<P> {
+
+    Plugin plugin;
+    String hookPluginName;
+    P hookedPlugin;
+    boolean enabled;
+
+    public AbstractPluginHook(Plugin plugin, String hookPluginName) {
+        this.plugin = plugin;
+        this.hookPluginName = hookPluginName;
+        this.enabled = false;
+    }
+
+    public abstract void check();
+
+}


### PR DESCRIPTION
Introduce an abstract class to streamline plugin hooking and integration. Provides a blueprint for managing hooked plugins, including initialization and activation status tracking. This addition simplifies extending plugin functionality.