### PR TITLE
make baseAPI abstract

### DIFF
--- a/src/main/java/de/varilx/BaseAPI.java
+++ b/src/main/java/de/varilx/BaseAPI.java
@@ -1,61 +1,40 @@
 package de.varilx;
 
 import de.varilx.configuration.VaxConfiguration;
-import de.varilx.configuration.file.YamlConfiguration;
-import de.varilx.inventory.controller.GameInventoryController;
-import de.varilx.utils.Metrics;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.FieldDefaults;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.InputStream;
-import java.util.*;
+import java.util.logging.Logger;
 
-@Getter
-@FieldDefaults(level = AccessLevel.PRIVATE)
-public class BaseAPI {
+public abstract class BaseAPI {
 
-    @Getter
-    static BaseAPI baseAPI;
+    private static BaseAPI INSTANCE;
 
-    final JavaPlugin plugin;
-    final GameInventoryController gameInventoryController;
-    final Map<String, VaxConfiguration> languageConfigurations;
-    final Metrics metrics;
-
-    final int pluginId;
-
-    VaxConfiguration configuration;
-    VaxConfiguration databaseConfiguration;
-
-    public BaseAPI(JavaPlugin plugin, int pluginId) {
-        this.plugin = plugin;
-        this.pluginId = pluginId;
-        this.languageConfigurations = new HashMap<>();
-        this.gameInventoryController = new GameInventoryController(this);
-        this.metrics = new Metrics(plugin, pluginId);
-        BaseAPI.baseAPI = this;
+    public static BaseAPI get() {
+        return BaseAPI.INSTANCE;
     }
 
-    public void enable() {
-        this.databaseConfiguration = new VaxConfiguration(plugin.getDataFolder(), "database.yml");
-        this.configuration = new VaxConfiguration(plugin.getDataFolder(), "config.yml");
+    public static void set(BaseAPI instance) {
+        if (INSTANCE != null) throw new IllegalStateException("Already initialized");
+        BaseAPI.INSTANCE = instance;
+    }
 
-        Locale.availableLocales().forEach(locale -> {
-            @Nullable InputStream resource = plugin.getResource("lang/" + locale.getLanguage() + ".yml");
-            if (resource == null) return;
-            if (locale.getLanguage().isEmpty()) return;
+    public Logger getLogger() {
+        return Logger.getLogger("BaseAPI");
+    }
 
-            VaxConfiguration config = new VaxConfiguration(plugin.getDataFolder(), "lang/" + locale.getLanguage() + ".yml");
-            this.languageConfigurations.put(locale.getLanguage(), config);
-        });
-        metrics.addCustomChart(new Metrics.SimplePie("used_language", () -> {
-            String language = configuration.getString("language", "en");
-            if (!this.languageConfigurations.containsKey(language)) return "en";
-            return language;
-        }));
+    @Nullable // When enable is not called
+    public abstract VaxConfiguration getDatabaseConfiguration();
+    @Nullable // When enable is not called
+    public abstract VaxConfiguration getConfiguration();
+
+    public final VaxConfiguration getCurrentLanguageConfiguration() {
+        return this.getLanguageConfiguration(this.getLanguage());
+    }
+
+    public abstract VaxConfiguration getLanguageConfiguration(String language);
+
+    public final String getLanguage() {
+        return this.getConfiguration().getString("language", "en");
     }
 
 }

--- a/src/main/java/de/varilx/BaseAPI.java
+++ b/src/main/java/de/varilx/BaseAPI.java
@@ -22,6 +22,9 @@ public abstract class BaseAPI {
         return Logger.getLogger("BaseAPI");
     }
 
+    public abstract boolean isDatabaseDisabled();
+
+
     @Nullable // When enable is not called
     public abstract VaxConfiguration getDatabaseConfiguration();
     @Nullable // When enable is not called

--- a/src/main/java/de/varilx/BaseSpigotAPI.java
+++ b/src/main/java/de/varilx/BaseSpigotAPI.java
@@ -24,6 +24,8 @@ public class BaseSpigotAPI extends BaseAPI {
 
     final int pluginId;
 
+    boolean isDatabaseDisabled = false;
+
     VaxConfiguration configuration;
     VaxConfiguration databaseConfiguration;
 
@@ -36,9 +38,14 @@ public class BaseSpigotAPI extends BaseAPI {
         BaseAPI.set(this);
     }
 
+    public BaseSpigotAPI disableDatabase() {
+        this.isDatabaseDisabled = true;
+        return this;
+    }
+
     public void enable() {
         this.databaseConfiguration = new VaxConfiguration(plugin.getDataFolder(), "database.yml");
-        this.configuration = new VaxConfiguration(plugin.getDataFolder(), "config.yml");
+        if (!this.isDatabaseDisabled()) this.configuration = new VaxConfiguration(plugin.getDataFolder(), "config.yml");
 
         Locale.availableLocales().forEach(locale -> {
             @Nullable InputStream resource = plugin.getResource("lang/" + locale.getLanguage() + ".yml");
@@ -68,6 +75,11 @@ public class BaseSpigotAPI extends BaseAPI {
     @Override
     public Logger getLogger() {
         return this.plugin.getLogger();
+    }
+
+    @Override
+    public boolean isDatabaseDisabled() {
+        return this.isDatabaseDisabled;
     }
 
     @Override

--- a/src/main/java/de/varilx/BaseSpigotAPI.java
+++ b/src/main/java/de/varilx/BaseSpigotAPI.java
@@ -1,0 +1,77 @@
+package de.varilx;
+
+import de.varilx.configuration.VaxConfiguration;
+import de.varilx.inventory.controller.GameInventoryController;
+import de.varilx.utils.Metrics;
+import lombok.Getter;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class BaseSpigotAPI extends BaseAPI {
+
+    @Getter
+    final JavaPlugin plugin;
+    @Getter
+    final GameInventoryController gameInventoryController;
+    final Map<String, VaxConfiguration> languageConfigurations;
+    final Metrics metrics;
+
+    final int pluginId;
+
+    VaxConfiguration configuration;
+    VaxConfiguration databaseConfiguration;
+
+    public BaseSpigotAPI(JavaPlugin plugin, int pluginId) {
+        this.plugin = plugin;
+        this.pluginId = pluginId;
+        this.languageConfigurations = new HashMap<>();
+        this.gameInventoryController = new GameInventoryController(this);
+        this.metrics = new Metrics(plugin, pluginId);
+        BaseAPI.set(this);
+    }
+
+    public void enable() {
+        this.databaseConfiguration = new VaxConfiguration(plugin.getDataFolder(), "database.yml");
+        this.configuration = new VaxConfiguration(plugin.getDataFolder(), "config.yml");
+
+        Locale.availableLocales().forEach(locale -> {
+            @Nullable InputStream resource = plugin.getResource("lang/" + locale.getLanguage() + ".yml");
+            if (resource == null) return;
+            if (locale.getLanguage().isEmpty()) return;
+
+            VaxConfiguration config = new VaxConfiguration(plugin.getDataFolder(), "lang/" + locale.getLanguage() + ".yml");
+            this.languageConfigurations.put(locale.getLanguage(), config);
+        });
+        metrics.addCustomChart(new Metrics.SimplePie("used_language", () -> {
+            String language = configuration.getString("language", "en");
+            if (!this.languageConfigurations.containsKey(language)) return "en";
+            return language;
+        }));
+    }
+
+    @Override
+    public @Nullable VaxConfiguration getConfiguration() {
+        return this.configuration;
+    }
+
+    @Override
+    public @Nullable VaxConfiguration getLanguageConfiguration(String language) {
+        return this.languageConfigurations.get(language);
+    }
+
+    @Override
+    public Logger getLogger() {
+        return this.plugin.getLogger();
+    }
+
+    @Override
+    public @Nullable VaxConfiguration getDatabaseConfiguration() {
+        return this.databaseConfiguration;
+    }
+}

--- a/src/main/java/de/varilx/GeneralBaseAPI.java
+++ b/src/main/java/de/varilx/GeneralBaseAPI.java
@@ -1,0 +1,70 @@
+package de.varilx;
+
+import de.varilx.configuration.VaxConfiguration;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.java.Log;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Logger;
+
+@Log
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class GeneralBaseAPI extends BaseAPI {
+
+
+    final Map<String, VaxConfiguration> languageConfigurations;
+    final File dataFolder;
+    final ClassLoader loader;
+
+    @Nullable
+    VaxConfiguration configuration;
+    @Nullable
+    VaxConfiguration databaseConfiguration;
+
+    public GeneralBaseAPI(File dataFolder, ClassLoader loader) {
+        this.loader = loader;
+        this.dataFolder = dataFolder;
+        this.languageConfigurations = new HashMap<>();
+        BaseAPI.set(this);
+    }
+
+    public void enable() {
+        this.databaseConfiguration = new VaxConfiguration(dataFolder, "database.yml");
+        this.configuration = new VaxConfiguration(dataFolder, "config.yml");
+
+        Locale.availableLocales().forEach(locale -> {
+            @Nullable InputStream resource = loader.getResourceAsStream("lang/" + locale.getLanguage() + ".yml");
+            if (resource == null) return;
+            if (locale.getLanguage().isEmpty()) return;
+
+            VaxConfiguration config = new VaxConfiguration(dataFolder, "lang/" + locale.getLanguage() + ".yml");
+            this.languageConfigurations.put(locale.getLanguage(), config);
+        });
+    }
+
+    @Override
+    public @Nullable VaxConfiguration getConfiguration() {
+        return this.configuration;
+    }
+
+    @Override
+    public @Nullable VaxConfiguration getLanguageConfiguration(String language) {
+        return this.languageConfigurations.get(language);
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
+    }
+
+    @Override
+    public @Nullable VaxConfiguration getDatabaseConfiguration() {
+        return this.databaseConfiguration;
+    }
+}

--- a/src/main/java/de/varilx/GeneralBaseAPI.java
+++ b/src/main/java/de/varilx/GeneralBaseAPI.java
@@ -22,6 +22,8 @@ public class GeneralBaseAPI extends BaseAPI {
     final File dataFolder;
     final ClassLoader loader;
 
+    boolean isDatabaseDisabled = false;
+
     @Nullable
     VaxConfiguration configuration;
     @Nullable
@@ -32,6 +34,11 @@ public class GeneralBaseAPI extends BaseAPI {
         this.dataFolder = dataFolder;
         this.languageConfigurations = new HashMap<>();
         BaseAPI.set(this);
+    }
+
+    public GeneralBaseAPI disableDatabase() {
+        this.isDatabaseDisabled = true;
+        return this;
     }
 
     public void enable() {
@@ -61,6 +68,11 @@ public class GeneralBaseAPI extends BaseAPI {
     @Override
     public Logger getLogger() {
         return log;
+    }
+
+    @Override
+    public boolean isDatabaseDisabled() {
+        return this.isDatabaseDisabled;
     }
 
     @Override

--- a/src/main/java/de/varilx/configuration/VaxConfiguration.java
+++ b/src/main/java/de/varilx/configuration/VaxConfiguration.java
@@ -1,13 +1,12 @@
 package de.varilx.configuration;
 
+import de.varilx.BaseAPI;
 import de.varilx.configuration.file.YamlConfiguration;
-import lombok.Getter;
 
 import java.io.*;
 
-public class VaxConfiguration {
+public class VaxConfiguration extends YamlConfiguration {
 
-    @Getter
     private YamlConfiguration config;
     private final File configFile;
 
@@ -41,22 +40,26 @@ public class VaxConfiguration {
     }
 
     public void reload() {
-        this.config = YamlConfiguration.loadConfiguration(this.configFile);
+        if (this.configFile == null) {
+            BaseAPI.get().getLogger().warning("Tried to save file while file is not set");
+            return;
+        }
+        try {
+            this.config.load(this.configFile);
+        } catch (IOException | InvalidConfigurationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void saveConfig() {
+        if (this.configFile == null) {
+            BaseAPI.get().getLogger().warning("Tried to save file while file is not set");
+            return;
+        }
         try {
             config.save(configFile);
         } catch (IOException e) {
             e.printStackTrace();
         }
-    }
-
-    public String getString(String path) {
-        return this.config.getString(path);
-    }
-
-    public String getString(String path, String defaultValue) {
-        return this.config.getString(path, defaultValue);
     }
 }

--- a/src/main/java/de/varilx/configuration/VaxConfiguration.java
+++ b/src/main/java/de/varilx/configuration/VaxConfiguration.java
@@ -7,12 +7,15 @@ import java.io.*;
 
 public class VaxConfiguration extends YamlConfiguration {
 
-    private YamlConfiguration config;
     private final File configFile;
 
     public VaxConfiguration(String yaml) {
         this.configFile = null;
-        this.config = YamlConfiguration.loadConfiguration(new StringReader(yaml));
+        try {
+            this.load(new StringReader(yaml));
+        } catch (IOException | InvalidConfigurationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public VaxConfiguration(File dataFolder, String configName) {
@@ -22,19 +25,24 @@ public class VaxConfiguration extends YamlConfiguration {
 
         this.configFile = new File(dataFolder, configName);
 
-        this.config = YamlConfiguration.loadConfiguration(configFile);
 
         if (!configFile.exists()) {
             try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(configName)) {
                 if (inputStream != null) {
                     YamlConfiguration defaultConfig = YamlConfiguration.loadConfiguration(new InputStreamReader(inputStream));
                     defaultConfig.save(configFile);
-                    this.config.setDefaults(defaultConfig);
+                    setDefaults(defaultConfig);
                 } else {
                     System.out.println("Could not find resource: " + configName);
                 }
             } catch (IOException e) {
                 e.printStackTrace();
+            }
+        } else {
+            try {
+                this.load(configFile);
+            } catch (IOException | InvalidConfigurationException e) {
+                throw new RuntimeException(e);
             }
         }
     }
@@ -45,7 +53,7 @@ public class VaxConfiguration extends YamlConfiguration {
             return;
         }
         try {
-            this.config.load(this.configFile);
+            this.load(this.configFile);
         } catch (IOException | InvalidConfigurationException e) {
             throw new RuntimeException(e);
         }
@@ -57,7 +65,7 @@ public class VaxConfiguration extends YamlConfiguration {
             return;
         }
         try {
-            config.save(configFile);
+            this.save(configFile);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/de/varilx/database/Service.java
+++ b/src/main/java/de/varilx/database/Service.java
@@ -37,7 +37,6 @@ public abstract class Service {
     }
 
     public static Service load(VaxConfiguration configuration, ClassLoader loader) {
-        System.out.println(configuration.getString("type"));
         @Nullable ServiceType type = ServiceType.findBy(configuration.getString("type"));
         if (type == null) throw new RuntimeException("No Database Type found");
         try {

--- a/src/main/java/de/varilx/database/Service.java
+++ b/src/main/java/de/varilx/database/Service.java
@@ -37,6 +37,7 @@ public abstract class Service {
     }
 
     public static Service load(VaxConfiguration configuration, ClassLoader loader) {
+        System.out.println(configuration.getString("type"));
         @Nullable ServiceType type = ServiceType.findBy(configuration.getString("type"));
         if (type == null) throw new RuntimeException("No Database Type found");
         try {

--- a/src/main/java/de/varilx/inventory/builder/GameInventoryBuilder.java
+++ b/src/main/java/de/varilx/inventory/builder/GameInventoryBuilder.java
@@ -1,6 +1,7 @@
 package de.varilx.inventory.builder;
 
 import de.varilx.BaseAPI;
+import de.varilx.BaseSpigotAPI;
 import de.varilx.inventory.GameInventory;
 import de.varilx.inventory.exception.GameInventoryBuildException;
 import de.varilx.inventory.item.ClickableItem;
@@ -8,7 +9,6 @@ import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 
 import java.util.HashMap;
 import java.util.List;
@@ -85,7 +85,7 @@ public class GameInventoryBuilder {
         } else {
             shadowInventory = new GameInventory(holder, (inventorySize == 0 ? 9 : inventorySize), inventoryName, pattern, items);
         }
-        baseAPI.getGameInventoryController().registerInventory(shadowInventory);
+        ((BaseSpigotAPI) baseAPI).getGameInventoryController().registerInventory(shadowInventory);
         return shadowInventory;
     }
 

--- a/src/main/java/de/varilx/inventory/controller/GameInventoryController.java
+++ b/src/main/java/de/varilx/inventory/controller/GameInventoryController.java
@@ -1,6 +1,7 @@
 package de.varilx.inventory.controller;
 
 import de.varilx.BaseAPI;
+import de.varilx.BaseSpigotAPI;
 import de.varilx.inventory.GameInventory;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
@@ -21,7 +22,7 @@ public class GameInventoryController implements Listener {
     List<GameInventory> inventories;
 
     public GameInventoryController(BaseAPI baseAPI) {
-        Plugin plugin = baseAPI.getPlugin();
+        Plugin plugin = ((BaseSpigotAPI) baseAPI).getPlugin();
         this.inventories = new ArrayList<>();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }

--- a/src/test/java/de/varilx/test/database/config/ConfigTest.java
+++ b/src/test/java/de/varilx/test/database/config/ConfigTest.java
@@ -1,0 +1,60 @@
+package de.varilx.test.database.config;
+
+import de.varilx.configuration.VaxConfiguration;
+import org.codehaus.plexus.util.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+public class ConfigTest {
+
+    @Test
+    public void testRawString() {
+        VaxConfiguration configuration = new VaxConfiguration("""
+                test:
+                 test: 
+                  1: abc
+                """);
+        assertThat(configuration.getString("test.test.1")).isEqualTo("abc");
+    }
+
+    @Test
+    public void testFile() throws IOException {
+        File config = new File(".", "test.yml");
+        config.createNewFile();
+
+        new FileOutputStream(config).write("""
+                test:
+                 test: 
+                  1: abc
+                """.getBytes(StandardCharsets.UTF_8));
+
+        VaxConfiguration configuration = new VaxConfiguration(new File("."), "test.yml");
+
+        assertThat(configuration.getString("test.test.1")).isEqualTo("abc");
+    }
+
+    @Test
+    public void testDefaults() {
+        VaxConfiguration configuration = new VaxConfiguration(new File("."), "test.yml");
+        assertThat(configuration.getString("abc.test.1")).isEqualTo("true");
+        assertThat(new File(".", "test.yml").exists()).isTrue();
+
+    }
+
+    @AfterEach
+    @BeforeEach
+    public void delete() throws IOException {
+        File config = new File(".", "test.yml");
+        FileUtils.forceDelete(config);
+    }
+
+}

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -1,0 +1,3 @@
+abc:
+  test:
+    1: true


### PR DESCRIPTION
This PR will be a breaking change, it will change the fundemental of the BaseAPI class:

### Like the name already says, the BaseAPI class will be abstract and currently we have two implementations:
- GeneralBaseAPI: Supports external services like a proxy, ...
- SpigotBaseAPI: Is designed that only spigot can use it

Every spigot plugin will have to change:
`new BaseAPI(...)` -> `new BaseSpigotAPI(...)`