### PR TITLE
Add method to retrieve message string lists from language files

### DIFF
--- a/src/main/java/de/varilx/utils/language/LanguageUtils.java
+++ b/src/main/java/de/varilx/utils/language/LanguageUtils.java
@@ -36,6 +36,16 @@ public class LanguageUtils {
         return components;
     }
 
+    public List<String> getMessageStringList(String path) {
+        String language = Optional.ofNullable(BaseAPI.get().getConfiguration().getString("language")).orElse("en");
+        @Nullable List<String> raw = BaseAPI.get().getCurrentLanguageConfiguration().getStringList(path);
+        if (raw == null) {
+            BaseAPI.get().getLogger().warning(path + " was not found in lang/" + language + ".yml");
+            return List.of("Path: " + path + " not found!");
+        }
+        return raw;
+    }
+
     public String getMessageString(String path) {
         String language = Optional.ofNullable(BaseAPI.get().getConfiguration().getString("language")).orElse("en");
         @Nullable String raw = BaseAPI.get().getCurrentLanguageConfiguration().getString(path);

--- a/src/main/java/de/varilx/utils/language/LanguageUtils.java
+++ b/src/main/java/de/varilx/utils/language/LanguageUtils.java
@@ -39,7 +39,7 @@ public class LanguageUtils {
     public List<String> getMessageStringList(String path) {
         String language = Optional.ofNullable(BaseAPI.get().getConfiguration().getString("language")).orElse("en");
         @Nullable List<String> raw = BaseAPI.get().getCurrentLanguageConfiguration().getStringList(path);
-        if (raw == null) {
+        if (raw.isEmpty()) {
             BaseAPI.get().getLogger().warning(path + " was not found in lang/" + language + ".yml");
             return List.of("Path: " + path + " not found!");
         }

--- a/src/main/java/de/varilx/utils/language/LanguageUtils.java
+++ b/src/main/java/de/varilx/utils/language/LanguageUtils.java
@@ -38,7 +38,7 @@ public class LanguageUtils {
 
     public List<String> getMessageStringList(String path) {
         String language = Optional.ofNullable(BaseAPI.get().getConfiguration().getString("language")).orElse("en");
-        @Nullable List<String> raw = BaseAPI.get().getCurrentLanguageConfiguration().getStringList(path);
+        List<String> raw = BaseAPI.get().getCurrentLanguageConfiguration().getStringList(path);
         if (raw.isEmpty()) {
             BaseAPI.get().getLogger().warning(path + " was not found in lang/" + language + ".yml");
             return List.of("Path: " + path + " not found!");


### PR DESCRIPTION
This commit introduces a method `getMessageStringList` to fetch lists of strings from language configuration files. It includes error handling to log warnings and return a default message when the specified path is not found. This enhances flexibility when working with multilingual string lists.